### PR TITLE
Time

### DIFF
--- a/personal_test.go
+++ b/personal_test.go
@@ -108,7 +108,7 @@ var statementsResponseBody = `[
 
 var expectedStatementsResponse = []mono.StatementItem{{
 	ID:                  "ZuHWzqkKGVo=",
-	Time:                1554466347,
+	Time:                mono.Time(time.Unix(1554466347, 0)),
 	Description:         "Покупка щастя",
 	MCC:                 7997,
 	Hold:                false,
@@ -247,7 +247,7 @@ var webhookParsed = mono.WebhookData{
 		AccountID: "deadbeef",
 		StatementItem: mono.StatementItem{
 			ID:                  "ZuHWzqkKGVo=",
-			Time:                1554466347,
+			Time:                mono.Time(time.Unix(1554466347, 0)),
 			Description:         "Покупка щастя",
 			MCC:                 7997,
 			Hold:                false,

--- a/personal_test.go
+++ b/personal_test.go
@@ -108,7 +108,7 @@ var statementsResponseBody = `[
 
 var expectedStatementsResponse = []mono.StatementItem{{
 	ID:                  "ZuHWzqkKGVo=",
-	Time:                mono.Time(time.Unix(1554466347, 0)),
+	Time:                mono.Time(1554466347),
 	Description:         "Покупка щастя",
 	MCC:                 7997,
 	Hold:                false,
@@ -247,7 +247,7 @@ var webhookParsed = mono.WebhookData{
 		AccountID: "deadbeef",
 		StatementItem: mono.StatementItem{
 			ID:                  "ZuHWzqkKGVo=",
-			Time:                mono.Time(time.Unix(1554466347, 0)),
+			Time:                mono.Time(1554466347),
 			Description:         "Покупка щастя",
 			MCC:                 7997,
 			Hold:                false,

--- a/public_test.go
+++ b/public_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
+	"time"
 
 	mono "github.com/kudrykv/go-monobank-api"
 )
@@ -28,7 +29,7 @@ var failResponseBody = `{
 var expectedCurrencyResponseBody = []mono.CurrencyInfo{{
 	CurrencyCodeAISO4217: 840,
 	CurrencyCodeBISO4217: 980,
-	Date:                 1552392228,
+	Date:                 mono.Time(time.Unix(1552392228, 0)),
 	RateSell:             27,
 	RateBuy:              27.2,
 	RateCross:            27.1,

--- a/public_test.go
+++ b/public_test.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
-	"time"
 
 	mono "github.com/kudrykv/go-monobank-api"
 )
@@ -29,7 +28,7 @@ var failResponseBody = `{
 var expectedCurrencyResponseBody = []mono.CurrencyInfo{{
 	CurrencyCodeAISO4217: 840,
 	CurrencyCodeBISO4217: 980,
-	Date:                 mono.Time(time.Unix(1552392228, 0)),
+	Date:                 mono.Time(1552392228),
 	RateSell:             27,
 	RateBuy:              27.2,
 	RateCross:            27.1,

--- a/types.go
+++ b/types.go
@@ -2,9 +2,14 @@ package mono
 
 import (
 	"strconv"
+	"time"
 )
 
 type Time int64
+
+func (t Time) Time() time.Time {
+	return time.Unix(int64(t), 0)
+}
 
 func (t *Time) UnmarshalJSON(bts []byte) error {
 	if string(bts) == "null" {

--- a/types.go
+++ b/types.go
@@ -2,10 +2,9 @@ package mono
 
 import (
 	"strconv"
-	"time"
 )
 
-type Time time.Time
+type Time int64
 
 func (t *Time) UnmarshalJSON(bts []byte) error {
 	if string(bts) == "null" {
@@ -17,7 +16,7 @@ func (t *Time) UnmarshalJSON(bts []byte) error {
 		return err
 	}
 
-	*t = Time(time.Unix(num, 0))
+	*t = Time(num)
 
 	return nil
 }

--- a/types.go
+++ b/types.go
@@ -1,7 +1,6 @@
 package mono
 
 import (
-	"strconv"
 	"time"
 )
 
@@ -9,21 +8,6 @@ type Time int64
 
 func (t Time) Time() time.Time {
 	return time.Unix(int64(t), 0)
-}
-
-func (t *Time) UnmarshalJSON(bts []byte) error {
-	if string(bts) == "null" {
-		return nil
-	}
-
-	num, err := strconv.ParseInt(string(bts), 10, 64)
-	if err != nil {
-		return err
-	}
-
-	*t = Time(num)
-
-	return nil
 }
 
 // UserInfo describes customer and customer's accounts.

--- a/types.go
+++ b/types.go
@@ -1,5 +1,27 @@
 package mono
 
+import (
+	"strconv"
+	"time"
+)
+
+type Time time.Time
+
+func (t *Time) UnmarshalJSON(bts []byte) error {
+	if string(bts) == "null" {
+		return nil
+	}
+
+	num, err := strconv.ParseInt(string(bts), 10, 64)
+	if err != nil {
+		return err
+	}
+
+	*t = Time(time.Unix(num, 0))
+
+	return nil
+}
+
 // UserInfo describes customer and customer's accounts.
 type UserInfo struct {
 	// Name describes client name.
@@ -31,7 +53,7 @@ type StatementItem struct {
 	// Transaction identifier.
 	ID string `json:"id"`
 	// Time when the transaction was made in UNIX timestamp.
-	Time        int64  `json:"time"`
+	Time        Time   `json:"time"`
 	Description string `json:"description"`
 	// Merchant Category Code
 	MCC int `json:"mcc"`
@@ -56,7 +78,7 @@ type CurrencyInfo struct {
 	CurrencyCodeAISO4217 int `json:"currencyCodeA"`
 	CurrencyCodeBISO4217 int `json:"currencyCodeB"`
 	// Rate at the given point of time in UNIX timestamp.
-	Date      int64   `json:"date"`
+	Date      Time    `json:"date"`
 	RateSell  float64 `json:"rateSell"`
 	RateBuy   float64 `json:"rateBuy"`
 	RateCross float64 `json:"rateCross"`

--- a/types.go
+++ b/types.go
@@ -4,8 +4,10 @@ import (
 	"time"
 )
 
+// Time wraps int64 to add a func for converting the value to time.Time.
 type Time int64
 
+// Time creates the time.Time from the int64 value.
 func (t Time) Time() time.Time {
 	return time.Unix(int64(t), 0)
 }

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,18 @@
+package mono_test
+
+import (
+	"testing"
+
+	mono "github.com/kudrykv/go-monobank-api"
+)
+
+func TestTime_UnmarshalJSON(t *testing.T) {
+	tt := mono.Time(0)
+	expectNoError(t, tt.UnmarshalJSON([]byte("null")))
+	expectDeepEquals(t, tt, mono.Time(0))
+
+	expectNoError(t, tt.UnmarshalJSON([]byte("1554466347")))
+	expectDeepEquals(t, tt, mono.Time(1554466347))
+
+	expectError(t, tt.UnmarshalJSON([]byte("1554bubu47")), "strconv.ParseInt: parsing \"1554bubu47\": invalid syntax")
+}

--- a/types_test.go
+++ b/types_test.go
@@ -2,9 +2,14 @@ package mono_test
 
 import (
 	"testing"
+	"time"
 
 	mono "github.com/kudrykv/go-monobank-api"
 )
+
+func TestTime_Time(t *testing.T) {
+	expectEquals(t, mono.Time(123).Time(), time.Unix(123, 0))
+}
 
 func TestTime_UnmarshalJSON(t *testing.T) {
 	tt := mono.Time(0)

--- a/types_test.go
+++ b/types_test.go
@@ -10,14 +10,3 @@ import (
 func TestTime_Time(t *testing.T) {
 	expectEquals(t, mono.Time(123).Time(), time.Unix(123, 0))
 }
-
-func TestTime_UnmarshalJSON(t *testing.T) {
-	tt := mono.Time(0)
-	expectNoError(t, tt.UnmarshalJSON([]byte("null")))
-	expectDeepEquals(t, tt, mono.Time(0))
-
-	expectNoError(t, tt.UnmarshalJSON([]byte("1554466347")))
-	expectDeepEquals(t, tt, mono.Time(1554466347))
-
-	expectError(t, tt.UnmarshalJSON([]byte("1554bubu47")), "strconv.ParseInt: parsing \"1554bubu47\": invalid syntax")
-}


### PR DESCRIPTION
Name `int64` as `Time` to add shortcut `Time()` method to get native `time.Time`.